### PR TITLE
Refactor routing from hash-based to path-based for improved navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "fast-glob": "^3.3.2",
         "fs-extra": "^11.2.0",
         "mime": "^4.0.3",
-        "morgan": "^1.10.0"
+        "morgan": "^1.10.0",
+        "nunjucks": "^3.2.4"
       },
       "devDependencies": {
         "nodemon": "^3.1.10"
@@ -54,6 +55,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -85,6 +91,11 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -230,6 +241,14 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/concat-map": {
@@ -949,6 +968,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nunjucks": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
+      "dependencies": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "commander": "^5.1.0"
+      },
+      "bin": {
+        "nunjucks-precompile": "bin/precompile"
+      },
+      "engines": {
+        "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",
     "mime": "^4.0.3",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "nunjucks": "^3.2.4"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/public/channel/index.html
+++ b/public/channel/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Araglas – Channel</title>
+  <link rel="stylesheet" href="/app-main.css" id="theme-dark" />
+  <link rel="stylesheet" href="/app-main-light.css" id="theme-light" disabled />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+  <link rel="icon" type="image/png" href="/icons/araglas.ico" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <div id="app"></div>
+  <script type="module">
+    import { renderChannel } from '/pages/channel.js';
+    import { applyThemeFromSettings, attachGlobals } from '/pages/_shared.js';
+    import { loadNavbar } from '/partials/navbar.js';
+    applyThemeFromSettings();
+    attachGlobals();
+    loadNavbar();
+    renderChannel();
+  </script>
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/public/channels/index.html
+++ b/public/channels/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Araglas – Channels</title>
+  <link rel="stylesheet" href="/app-main.css" id="theme-dark" />
+  <link rel="stylesheet" href="/app-main-light.css" id="theme-light" disabled />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+  <link rel="icon" type="image/png" href="/icons/araglas.ico" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <div id="app"></div>
+  <script type="module">
+    import { renderChannels } from '/pages/channels.js';
+    import { applyThemeFromSettings, attachGlobals } from '/pages/_shared.js';
+    import { loadNavbar } from '/partials/navbar.js';
+    applyThemeFromSettings();
+    attachGlobals();
+    loadNavbar();
+    renderChannels();
+  </script>
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/public/core/components.js
+++ b/public/core/components.js
@@ -21,8 +21,8 @@ export function cardVideo(v) {
   const formatted = formatTitle(v.name);
   const showTitle = formatted.length > 40 ? formatted.slice(0, 37) + '...' : formatted;
   const infoLine = [ v.channel || '', v.mtime ? fmtDate(v.mtime) : '' ].filter(Boolean).join(' | ');
-  function goToWatch(){ location.hash = `#/watch?relPath=${encodeURIComponent(v.relPath)}&channel=${encodeURIComponent(v.channel)}&title=${encodeURIComponent(formatTitle(v.name))}`; }
-  function refreshRoute(){ window.dispatchEvent(new Event('hashchange')); }
+  function goToWatch(){ location.href = `/watch/?relPath=${encodeURIComponent(v.relPath)}&channel=${encodeURIComponent(v.channel)}&title=${encodeURIComponent(formatTitle(v.name))}`; }
+  function refreshRoute(){ location.reload(); }
   function showDropdown(e){
     e.stopPropagation();
     const old = document.getElementById('video-dropdown');

--- a/public/favorites/index.html
+++ b/public/favorites/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Araglas – Favorites</title>
+  <link rel="stylesheet" href="/app-main.css" id="theme-dark" />
+  <link rel="stylesheet" href="/app-main-light.css" id="theme-light" disabled />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+  <link rel="icon" type="image/png" href="/icons/araglas.ico" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <div id="app"></div>
+  <script type="module">
+    import { renderFavorites } from '/pages/favorites.js';
+    import { applyThemeFromSettings, attachGlobals } from '/pages/_shared.js';
+    import { loadNavbar } from '/partials/navbar.js';
+    applyThemeFromSettings();
+    attachGlobals();
+    loadNavbar();
+    renderFavorites();
+  </script>
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/public/home/index.html
+++ b/public/home/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Araglas – Home</title>
+  <link rel="stylesheet" href="/app-main.css" id="theme-dark" />
+  <link rel="stylesheet" href="/app-main-light.css" id="theme-light" disabled />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+  <link rel="icon" type="image/png" href="/icons/araglas.ico" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <div id="app"></div>
+  <script type="module">
+    import { renderHome } from '/pages/home.js';
+    import { applyThemeFromSettings, attachGlobals } from '/pages/_shared.js';
+    import { loadNavbar } from '/partials/navbar.js';
+    applyThemeFromSettings();
+    attachGlobals();
+    loadNavbar();
+    renderHome();
+  </script>
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/public/moments/index.html
+++ b/public/moments/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Araglas – Moments</title>
+  <link rel="stylesheet" href="/app-main.css" id="theme-dark" />
+  <link rel="stylesheet" href="/app-main-light.css" id="theme-light" disabled />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+  <link rel="icon" type="image/png" href="/icons/araglas.ico" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <div id="app"></div>
+  <script type="module">
+    import { renderMoments } from '/pages/moments.js';
+    import { applyThemeFromSettings, attachGlobals } from '/pages/_shared.js';
+    import { loadNavbar } from '/partials/navbar.js';
+    applyThemeFromSettings();
+    attachGlobals();
+    loadNavbar();
+    renderMoments();
+  </script>
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/public/pages/_shared.js
+++ b/public/pages/_shared.js
@@ -1,0 +1,82 @@
+// Shared client utilities for path-based pages
+import { api } from '/core/api.js';
+
+export async function getThemeSetting() {
+  try {
+    const res = await fetch('/api/user-settings');
+    const data = await res.json();
+    return data.theme || 'dark';
+  } catch { return 'dark'; }
+}
+
+export function applyTheme(theme) {
+  const darkLink = document.getElementById('theme-dark');
+  const lightLink = document.getElementById('theme-light');
+  if (theme === 'light') {
+    if (darkLink) darkLink.disabled = true;
+    if (lightLink) lightLink.disabled = false;
+  } else {
+    if (darkLink) darkLink.disabled = false;
+    if (lightLink) lightLink.disabled = true;
+  }
+  window.currentTheme = theme;
+}
+
+export async function applyThemeFromSettings() {
+  const t = await getThemeSetting();
+  applyTheme(t);
+}
+
+export function getQueryParams() {
+  const params = new URLSearchParams(window.location.search || '');
+  return Object.fromEntries(params.entries());
+}
+
+async function setThemeSetting(theme) {
+  await fetch('/api/user-settings', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ theme }) });
+}
+
+export async function toggleTheme() {
+  const current = window.currentTheme || (document.getElementById('theme-light')?.disabled ? 'dark' : 'light');
+  const next = current === 'dark' ? 'light' : 'dark';
+  applyTheme(next);
+  await setThemeSetting(next);
+}
+
+export function attachGlobals() {
+  // Surprise me: pick random channel and random video
+  window.surpriseMe = function surpriseMe() {
+    api('/api/channels?page=1&pageSize=96').then(chs => {
+      const channels = chs.data || [];
+      if (!channels.length) return alert('No channels found.');
+      const randChannel = channels[Math.floor(Math.random()*channels.length)];
+      const channelId = randChannel.id; const channelName = randChannel.name;
+      api(`/api/channels/${encodeURIComponent(channelId)}/videos?page=1&pageSize=96`).then(vs => {
+        const videos = vs.data || [];
+        if (!videos.length) return alert('No videos found in channel.');
+        const randVideo = videos[Math.floor(Math.random()*videos.length)];
+        window.location = `/watch/?relPath=${encodeURIComponent(randVideo.relPath)}&channel=${encodeURIComponent(channelName)}&title=${encodeURIComponent(randVideo.name)}`;
+      }).catch(err => alert('Failed to fetch videos: ' + err.message));
+    }).catch(err => alert('Failed to fetch channels: ' + err.message));
+  };
+
+  // Theme toggle
+  window.toggleTheme = toggleTheme;
+
+  // Optional admin actions (if used elsewhere)
+  window.manualRescan = async function manualRescan() {
+    try {
+      const res = await fetch('/api/rescan', { method: 'POST' });
+      const data = await res.json();
+      if (data.ok) alert('Library rescan complete.'); else alert('Rescan failed: ' + (data.error || 'Unknown error'));
+    } catch (err) { alert('Rescan failed: ' + err.message); }
+  }
+  window.cleanupThumbs = async function cleanupThumbs() {
+    try {
+      const res = await fetch('/api/cleanup-thumbs', { method: 'POST' });
+      const data = await res.json();
+      if (data.ok) alert(`Cleanup complete. Deleted ${data.deleted} thumbnails.`);
+      else alert('Cleanup failed: ' + (data.error || 'Unknown error'));
+    } catch (err) { alert('Cleanup failed: ' + err.message); }
+  }
+}

--- a/public/pages/channel.js
+++ b/public/pages/channel.js
@@ -3,11 +3,11 @@ import { h, fmtDate, fmtSize, formatTitle } from '/core/helpers.js';
 import { api, videoUrl } from '/core/api.js';
 import { renderLayout, pagination, lazyThumbs } from '/core/ui.js';
 import { cardVideo } from '/core/components.js';
-import { parseHashParams } from '/core/router-hash.js';
+import { getQueryParams } from '/pages/_shared.js';
 import { state } from '/core/stores.js';
 
 export async function renderChannel() {
-  const params = parseHashParams();
+  const params = getQueryParams();
   const id = params.id;
   const name = params.name || id;
   const page = Number(params.page || 1);
@@ -20,7 +20,7 @@ export async function renderChannel() {
     h('div', {},
       h('div', { class: 'notice', style: 'text-align:center;font-size:1.2em;font-weight:700;margin:18px 0;' }, `Channel: ${name}`),
       data.data.length ? grid : h('div', { class: 'notice' }, 'No videos here.'),
-      pagination(data, (p) => { location.hash = `#/channel?id=${encodeURIComponent(id)}&name=${encodeURIComponent(name)}&q=${encodeURIComponent(q)}&page=${p}&pageSize=${pageSize}`; })
+  pagination(data, (p) => { location.href = `/channel/?id=${encodeURIComponent(id)}&name=${encodeURIComponent(name)}&q=${encodeURIComponent(q)}&page=${p}&pageSize=${pageSize}`; })
     )
   );
   lazyThumbs();

--- a/public/pages/channels.js
+++ b/public/pages/channels.js
@@ -3,26 +3,26 @@ import { h } from '/core/helpers.js';
 import { api } from '/core/api.js';
 import { renderLayout, pagination } from '/core/ui.js';
 import { cardChannel } from '/core/components.js';
-import { parseHashParams } from '/core/router-hash.js';
+import { getQueryParams } from '/pages/_shared.js';
 
 export async function renderChannels() {
-  const params = parseHashParams();
+  const params = getQueryParams();
   const page = Number(params.page || 1);
   const pageSize = Number(params.pageSize || 15);
   const q = params.q || '';
   const data = await api(`/api/channels?page=${page}&pageSize=${pageSize}&q=${encodeURIComponent(q)}`);
-  const grid = h('div', { class: 'grid' }, data.data.map(c => cardChannel(c, ()=> location.hash = `#/channel?id=${encodeURIComponent(c.id)}&name=${encodeURIComponent(c.name)}`)));
+  const grid = h('div', { class: 'grid' }, data.data.map(c => cardChannel(c, ()=> location.href = `/channel/?id=${encodeURIComponent(c.id)}&name=${encodeURIComponent(c.name)}`)));
   let channelQuery = q;
   let inputRef;
   const searchBar = h('div', { class: 'searchbar', style: 'width:250px; margin-bottom:0; position:relative; display:flex; align-items:center;' },
-    inputRef = h('input', { type: 'text', placeholder: 'Search channels…', value: channelQuery, class: '', oninput: (e)=>{ channelQuery = e.target.value; }, onkeydown: (e)=>{ if (e.key === 'Enter') { if (!channelQuery.trim()) { alert('Please enter a channel name to search.'); return; } location.hash = `#/channels?page=1&pageSize=${pageSize}&q=${encodeURIComponent(channelQuery.trim())}`; } } }),
-    h('button', { style: 'position:absolute;right:6px;background:none;border:none;cursor:pointer;padding:0 8px;font-size:18px;color:var(--muted);height:100%;display:flex;align-items:center;', onclick: ()=>{ channelQuery = ''; inputRef.value = ''; inputRef.focus(); location.hash = `#/channels?page=1&pageSize=${pageSize}&q=`; }, title: 'Clear search' }, h('i', { class: 'fa-solid fa-xmark' }))
+    inputRef = h('input', { type: 'text', placeholder: 'Search channels…', value: channelQuery, class: '', oninput: (e)=>{ channelQuery = e.target.value; }, onkeydown: (e)=>{ if (e.key === 'Enter') { if (!channelQuery.trim()) { alert('Please enter a channel name to search.'); return; } location.href = `/channels/?page=1&pageSize=${pageSize}&q=${encodeURIComponent(channelQuery.trim())}`; } } }),
+    h('button', { style: 'position:absolute;right:6px;background:none;border:none;cursor:pointer;padding:0 8px;font-size:18px;color:var(--muted);height:100%;display:flex;align-items:center;', onclick: ()=>{ channelQuery = ''; inputRef.value = ''; inputRef.focus(); location.href = `/channels/?page=1&pageSize=${pageSize}&q=`; }, title: 'Clear search' }, h('i', { class: 'fa-solid fa-xmark' }))
   );
   renderLayout(
     h('div', {},
       h('div', { style: 'display:flex;justify-content:center;align-items:center;margin-bottom:18px;' }, searchBar),
       data.data.length ? grid : h('div', { class: 'notice' }, 'No channels found.'),
-      pagination(data, (p)=>{ location.hash = `#/channels?page=${p}&pageSize=${pageSize}&q=${encodeURIComponent(q)}`; })
+      pagination(data, (p)=>{ location.href = `/channels/?page=${p}&pageSize=${pageSize}&q=${encodeURIComponent(q)}`; })
     )
   );
 }

--- a/public/pages/favorites.js
+++ b/public/pages/favorites.js
@@ -1,7 +1,6 @@
 // pages/favorites.js
 import { h } from '/core/helpers.js';
 import { renderLayout, lazyThumbs } from '/core/ui.js';
-import { videoUrl } from '/core/api.js';
 import { loadFavs, state } from '/core/stores.js';
 import { cardVideo } from '/core/components.js';
 

--- a/public/pages/home.js
+++ b/public/pages/home.js
@@ -3,15 +3,15 @@ import { api } from '/core/api.js';
 import { h } from '/core/helpers.js';
 import { renderLayout, pagination, lazyThumbs } from '/core/ui.js';
 import { cardVideo } from '/core/components.js';
-import { parseHashParams } from '/core/router-hash.js';
+import { getQueryParams } from '/pages/_shared.js';
 
 export async function renderHome() {
-  const params = parseHashParams();
+  const params = getQueryParams();
   const page = Number(params.page || 1);
   const pageSize = Number(params.pageSize || 15);
   const data = await api(`/api/search?q=&page=${page}&pageSize=${pageSize}`);
   const videos = data.data || [];
   const grid = h('div', { class: 'grid' }, videos.map(v => cardVideo(v)));
-  renderLayout(h('div', {}, videos.length ? grid : h('div', { class: 'notice' }, 'No videos found.'), pagination(data, (p)=>{ location.hash = `#/?page=${p}&pageSize=${pageSize}`; })));
+  renderLayout(h('div', {}, videos.length ? grid : h('div', { class: 'notice' }, 'No videos found.'), pagination(data, (p)=>{ location.href = `?page=${p}&pageSize=${pageSize}`; })));
   lazyThumbs();
 }

--- a/public/pages/moments.js
+++ b/public/pages/moments.js
@@ -2,10 +2,10 @@
 import { h, formatTitle, formatTimestamp } from '/core/helpers.js';
 import { api } from '/core/api.js';
 import { renderLayout, pagination } from '/core/ui.js';
-import { parseHashParams } from '/core/router-hash.js';
+import { getQueryParams } from '/pages/_shared.js';
 
 export async function renderMoments() {
-  const params = parseHashParams();
+  const params = getQueryParams();
   const page = Number(params.page || 1);
   const pageSize = 15;
   const resp = await api(`/api/moments?page=${page}&pageSize=${pageSize}`);
@@ -26,20 +26,20 @@ export async function renderMoments() {
               h('button', { style: 'background:var(--brand);color:var(--card);border:none;border-radius:6px;padding:6px 12px;cursor:pointer;font-weight:700;', onclick: () => {
                 const channel = relPath.split('/')[0];
                 const title = formatTitle(relPath.split('/').pop());
-                location.hash = `#/watch?relPath=${encodeURIComponent(relPath)}&channel=${encodeURIComponent(channel)}&title=${encodeURIComponent(title)}&timestamp=${m.timestamp}`;
+                location.href = `/watch/?relPath=${encodeURIComponent(relPath)}&channel=${encodeURIComponent(channel)}&title=${encodeURIComponent(title)}&timestamp=${m.timestamp}`;
               } }, `Play @ ${formatTimestamp(m.timestamp)}`),
               h('div', { style: 'font-weight:600;' }, m.title),
               h('button', { style: 'background:none;border:none;color:var(--muted);cursor:pointer;font-size:16px;', title: 'Delete moment', onclick: async () => {
                 if (confirm('Delete this moment?')) {
                   await fetch('/api/moments', { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ relPath, timestamp: m.timestamp }) });
-                  window.dispatchEvent(new Event('hashchange'));
+                  location.reload();
                 }
               } }, h('i', { class: 'fa-solid fa-trash' }))
             )
           )
         )
       ),
-      pagination({ page, totalPages }, (p) => { location.hash = `#/moments?page=${p}`; })
+  pagination({ page, totalPages }, (p) => { location.href = `/moments/?page=${p}`; })
     )
   );
 }

--- a/public/pages/playlists.js
+++ b/public/pages/playlists.js
@@ -1,6 +1,6 @@
 // pages/playlists.js
 import { h, fmtDate, fmtSize, formatTitle } from '/core/helpers.js';
-import { parseHashParams } from '/core/router-hash.js';
+import { getQueryParams } from '/pages/_shared.js';
 import { api, videoThumb, videoUrl } from '/core/api.js';
 import { renderLayout, pagination, lazyThumbs } from '/core/ui.js';
 import { state, loadPlaylists, createPlaylist, deletePlaylist, removeVideoFromPlaylist } from '/core/stores.js';
@@ -23,8 +23,8 @@ export async function renderPlaylists() {
           if (!name) return alert('Enter playlist name');
           await createPlaylist(name);
           e.target.reset();
-          // Refresh via hashchange
-          window.dispatchEvent(new Event('hashchange'));
+          // Refresh page after creating playlist
+          location.reload();
         },
         style: 'display:flex;gap:8px;margin-bottom:18px;'
       },
@@ -36,7 +36,7 @@ export async function renderPlaylists() {
           playlists.map(pl =>
             h('div', {
               style: 'display:flex;align-items:center;justify-content:space-between;padding:12px 0;border-bottom:1px solid #222;cursor:pointer;',
-              onclick: () => location.hash = `#/playlist?id=${encodeURIComponent(pl.id)}`
+              onclick: () => location.href = `/playlist/?id=${encodeURIComponent(pl.id)}`
             },
               h('div', {},
                 h('span', { style: 'font-weight:700;font-size:1.1em;' }, pl.name),
@@ -48,7 +48,7 @@ export async function renderPlaylists() {
                   e.stopPropagation();
                   if (confirm(`Delete playlist '${pl.name}'?`)) {
                     await deletePlaylist(pl.id);
-                    window.dispatchEvent(new Event('hashchange'));
+                    location.reload();
                   }
                 }
               }, h('i', { class: 'fa-solid fa-trash' }))
@@ -58,13 +58,13 @@ export async function renderPlaylists() {
             h('button', {
               style: `padding:6px 14px;border-radius:8px;border:none;background:${page > 1 ? 'var(--brand)' : '#444'};color:var(--card);cursor:${page > 1 ? 'pointer' : 'not-allowed'};`,
               disabled: page <= 1,
-              onclick: () => { if (page > 1) { state.playlistsPage = page - 1; window.dispatchEvent(new Event('hashchange')); } }
+              onclick: () => { if (page > 1) { state.playlistsPage = page - 1; location.reload(); } }
             }, 'Previous'),
             h('span', { style: 'align-self:center;' }, `Page ${page} of ${totalPages}`),
             h('button', {
               style: `padding:6px 14px;border-radius:8px;border:none;background:${page < totalPages ? 'var(--brand)' : '#444'};color:var(--card);cursor:${page < totalPages ? 'pointer' : 'not-allowed'};`,
               disabled: page >= totalPages,
-              onclick: () => { if (page < totalPages) { state.playlistsPage = page + 1; window.dispatchEvent(new Event('hashchange')); } }
+              onclick: () => { if (page < totalPages) { state.playlistsPage = page + 1; location.reload(); } }
             }, 'Next')
           )
         ) : h('div', { class: 'notice' }, 'No playlists yet.')
@@ -75,8 +75,9 @@ export async function renderPlaylists() {
 
 // Single playlist detail page
 export async function renderPlaylistDetail() {
-  const params = parseHashParams();
+  const params = getQueryParams();
   const id = params.id;
+  state.currentPlaylistId = id;
   await loadPlaylists();
   const playlist = state.playlists.find(pl => pl.id === id);
   if (!playlist) {
@@ -94,7 +95,7 @@ export async function renderPlaylistDetail() {
         class: 'thumb lazy',
         'data-src': videoThumb(v.relPath),
         alt: v.name,
-        onclick: () => { location.hash = `#/watch?relPath=${encodeURIComponent(v.relPath)}&channel=${encodeURIComponent(v.channel)}&title=${encodeURIComponent(formatTitle(v.name))}`; }
+  onclick: () => { location.href = `/watch/?relPath=${encodeURIComponent(v.relPath)}&channel=${encodeURIComponent(v.channel)}&title=${encodeURIComponent(formatTitle(v.name))}`; }
       }),
       h('div', { class: 'card-body' },
         h('div', { class: 'card-title', title: v.name }, formatTitle(v.name).length > 25 ? formatTitle(v.name).slice(0, 22) + '...' : formatTitle(v.name)),
@@ -110,7 +111,7 @@ export async function renderPlaylistDetail() {
               if (confirm('Remove this video from playlist?')) {
                 await removeVideoFromPlaylist(playlist.id, v.relPath);
                 await loadPlaylists();
-                window.dispatchEvent(new Event('hashchange'));
+                location.reload();
               }
             }
           }, 'Remove from Playlist')
@@ -124,7 +125,7 @@ export async function renderPlaylistDetail() {
     h('div', {},
       h('div', { class: 'notice', style: 'text-align:center;font-size:1.2em;font-weight:700;margin:18px 0;' }, `Playlist: ${playlist.name}`),
       videos.length ? grid : h('div', { class: 'notice' }, 'No videos in this playlist.'),
-      pagination({ page, totalPages }, (p) => { location.hash = `#/playlist?id=${encodeURIComponent(id)}&page=${p}&pageSize=${pageSize}`; })
+  pagination({ page, totalPages }, (p) => { location.href = `/playlist/?id=${encodeURIComponent(id)}&page=${p}&pageSize=${pageSize}`; })
     )
   );
   lazyThumbs();

--- a/public/pages/search.js
+++ b/public/pages/search.js
@@ -3,10 +3,10 @@ import { h } from '/core/helpers.js';
 import { api } from '/core/api.js';
 import { renderLayout, pagination, lazyThumbs } from '/core/ui.js';
 import { cardVideo } from '/core/components.js';
-import { parseHashParams } from '/core/router-hash.js';
+import { getQueryParams } from '/pages/_shared.js';
 
 export async function renderSearch() {
-  const params = parseHashParams();
+  const params = getQueryParams();
   const q = params.q || '';
   const page = Number(params.page || 1);
   const pageSize = Number(params.pageSize || 12);
@@ -16,7 +16,7 @@ export async function renderSearch() {
     h('div', {},
       h('div', { class: 'notice' }, `Search results for: "${q}"`),
       data.data.length ? grid : h('div', { class: 'notice' }, 'No videos found.'),
-      pagination(data, (p) => { location.hash = `#/search?q=${encodeURIComponent(q)}&page=${p}&pageSize=${pageSize}`; })
+  pagination(data, (p) => { location.href = `/search/?q=${encodeURIComponent(q)}&page=${p}&pageSize=${pageSize}`; })
     )
   );
   lazyThumbs();

--- a/public/pages/watch.js
+++ b/public/pages/watch.js
@@ -8,6 +8,8 @@ import { showPlaylistModal } from '/core/components.js';
 
 export async function renderWatch() {
   const params = getQueryParams();
+  console.debug('[renderWatch] params:', params);
+  try {
   const relPath = params.relPath;
   const channel = params.channel;
   const title = params.title;
@@ -77,7 +79,7 @@ export async function renderWatch() {
           h('button', { style: 'padding:10px 18px;border-radius:8px;background:var(--brand);color:var(--card);border:none;cursor:pointer;font-weight:700;font-size:1.08em;display:flex;align-items:center;gap:8px;', onclick: async () => { const player = document.getElementById('main-video-player'); if (!player) return; const ts = Math.floor(player.currentTime); const title = prompt('Moment at '+ts+'s title:'); if (!title) return; await fetch('/api/moments', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ relPath: video.relPath, timestamp: ts, title }) }); alert('Moment saved!'); } }, h('i', { class: 'fa-solid fa-hand-point-up', style: 'margin-right:8px;' }), 'Add Moment'),
           h('button', { style: 'padding:10px 18px;border-radius:8px;background:var(--brand);color:var(--card);border:none;cursor:pointer;font-weight:700;font-size:1.08em;display:flex;align-items:center;gap:8px;', onclick: (e) => { e.preventDefault(); showPlaylistModal(video); } }, h('i', { class: 'fa-solid fa-list', style: 'margin-right:8px;' }), 'Add to Playlist'),
           h('button', { style: 'padding:10px 18px;border-radius:8px;background:var(--brand);color:var(--card);border:none;cursor:pointer;font-weight:700;font-size:1.08em;display:flex;align-items:center;gap:8px;', onclick: async (e) => { e.preventDefault(); await addFav({ relPath: video.relPath, name: video.name, channel: video.channel, channelId: channelId, mtime: video.mtime, size: video.size }); alert('Added to Favorites!'); } }, h('i', { class: 'fa-solid fa-heart', style: 'margin-right:8px;' }), 'Add to Favorites')
-        )
+        ),
         // Metadata block (conditional if infoJson)
         infoJson ? h('div', { style: 'display:flex;flex-wrap:wrap;gap:16px;margin:8px 0 24px 0;padding:12px 16px;background:var(--card);border-radius:12px;border:1px solid #222;' },
           h('div', { style: 'display:flex;flex-direction:column;min-width:120px;' },
@@ -111,5 +113,14 @@ export async function renderWatch() {
 
   if (timestamp) {
     setTimeout(() => { const player = document.getElementById('main-video-player'); if (player) player.currentTime = timestamp; }, 600);
+  }
+  } catch (err) {
+    console.error('[renderWatch] error:', err);
+    try {
+      renderLayout(h('div', { class: 'notice' }, 'Failed to render watch page: ' + (err && err.message ? err.message : String(err))));
+    } catch (err2) {
+      // last resort: write to document
+      document.body.innerHTML = '<div style="padding:24px;font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;">Failed to render watch page.</div>';
+    }
   }
 }

--- a/public/pages/watch.js
+++ b/public/pages/watch.js
@@ -78,6 +78,33 @@ export async function renderWatch() {
           h('button', { style: 'padding:10px 18px;border-radius:8px;background:var(--brand);color:var(--card);border:none;cursor:pointer;font-weight:700;font-size:1.08em;display:flex;align-items:center;gap:8px;', onclick: (e) => { e.preventDefault(); showPlaylistModal(video); } }, h('i', { class: 'fa-solid fa-list', style: 'margin-right:8px;' }), 'Add to Playlist'),
           h('button', { style: 'padding:10px 18px;border-radius:8px;background:var(--brand);color:var(--card);border:none;cursor:pointer;font-weight:700;font-size:1.08em;display:flex;align-items:center;gap:8px;', onclick: async (e) => { e.preventDefault(); await addFav({ relPath: video.relPath, name: video.name, channel: video.channel, channelId: channelId, mtime: video.mtime, size: video.size }); alert('Added to Favorites!'); } }, h('i', { class: 'fa-solid fa-heart', style: 'margin-right:8px;' }), 'Add to Favorites')
         )
+        // Metadata block (conditional if infoJson)
+        infoJson ? h('div', { style: 'display:flex;flex-wrap:wrap;gap:16px;margin:8px 0 24px 0;padding:12px 16px;background:var(--card);border-radius:12px;border:1px solid #222;' },
+          h('div', { style: 'display:flex;flex-direction:column;min-width:120px;' },
+            h('span', { style: 'font-size:0.75em;text-transform:uppercase;color:var(--muted);letter-spacing:0.5px;' }, 'Views'),
+            h('span', { style: 'font-weight:700;font-size:1.05em;' }, humanizeNumber(infoJson.view_count, ''))
+          ),
+          infoJson.like_count ? h('div', { style: 'display:flex;flex-direction:column;min-width:120px;' },
+            h('span', { style: 'font-size:0.75em;text-transform:uppercase;color:var(--muted);letter-spacing:0.5px;' }, 'Likes'),
+            h('span', { style: 'font-weight:700;font-size:1.05em;' }, humanizeNumber(infoJson.like_count, ''))
+          ) : null,
+          infoJson.channel_follower_count ? h('div', { style: 'display:flex;flex-direction:column;min-width:140px;' },
+            h('span', { style: 'font-size:0.75em;text-transform:uppercase;color:var(--muted);letter-spacing:0.5px;' }, 'Subscribers'),
+            h('span', { style: 'font-weight:700;font-size:1.05em;' }, humanizeNumber(infoJson.channel_follower_count, ''))
+          ) : null,
+          infoJson.upload_date ? h('div', { style: 'display:flex;flex-direction:column;min-width:140px;' },
+            h('span', { style: 'font-size:0.75em;text-transform:uppercase;color:var(--muted);letter-spacing:0.5px;' }, 'Uploaded'),
+            h('span', { style: 'font-weight:700;font-size:1.05em;' }, humanizeDate(infoJson.upload_date))
+          ) : null,
+          infoJson.webpage_url ? h('div', { style: 'display:flex;flex-direction:column;min-width:160px;' },
+            h('span', { style: 'font-size:0.75em;text-transform:uppercase;color:var(--muted);letter-spacing:0.5px;' }, 'YouTube'),
+            h('a', { href: infoJson.webpage_url, target: '_blank', rel: 'noopener noreferrer', style: 'font-weight:700;font-size:1.05em;color:var(--brand);text-decoration:none;' }, 'Open ▶')
+          ) : null,
+          infoJson.duration ? h('div', { style: 'display:flex;flex-direction:column;min-width:100px;' },
+            h('span', { style: 'font-size:0.75em;text-transform:uppercase;color:var(--muted);letter-spacing:0.5px;' }, 'Duration'),
+            h('span', { style: 'font-weight:700;font-size:1.05em;' }, formatTimestamp(infoJson.duration))
+          ) : null
+        ) : null
       )
     )
   );

--- a/public/pages/watch.js
+++ b/public/pages/watch.js
@@ -2,12 +2,12 @@
 import { h, fmtSize, fmtDate, formatTitle, formatTimestamp } from '/core/helpers.js';
 import { api, videoUrl, channelCover } from '/core/api.js';
 import { renderLayout } from '/core/ui.js';
-import { parseHashParams } from '/core/router-hash.js';
+import { getQueryParams } from '/pages/_shared.js';
 import { addFav } from '/core/stores.js';
 import { showPlaylistModal } from '/core/components.js';
 
 export async function renderWatch() {
-  const params = parseHashParams();
+  const params = getQueryParams();
   const relPath = params.relPath;
   const channel = params.channel;
   const title = params.title;
@@ -69,7 +69,7 @@ export async function renderWatch() {
         h('div', { style: 'font-size:1.6em;font-weight:700;margin-bottom:8px;word-break:break-word;overflow-wrap:break-word;white-space:pre-line;max-width:100%;text-align:left;' }, formatTitle(video.name)),
         h('div', { style: 'display:flex;align-items:center;gap:12px;margin-bottom:6px;' },
           h('img', { src: channelCover(channelCoverPath || video.relPath.split('/')[0]), style: 'width:36px;height:36px;border-radius:50%;object-fit:cover;background:#222;', onerror: function() { this.src = '/icons/araglas.png'; } }),
-          h('a', { href: `#/channel?id=${encodeURIComponent(channelId)}&name=${encodeURIComponent(channel)}`, style: 'color:var(--brand);font-weight:700;text-decoration:none;font-size:1.08em;' }, channel),
+          h('a', { href: `/channel/?id=${encodeURIComponent(channelId)}&name=${encodeURIComponent(channel)}`, style: 'color:var(--brand);font-weight:700;text-decoration:none;font-size:1.08em;' }, channel),
           h('span', { style: 'margin-left:8px;color:var(--muted);font-size:1em;' }, `|  ${fmtDate(video.mtime)}`)
         ),
         h('div', { style: 'color:var(--muted);font-size:1em;margin-bottom:8px;' }, `Size: ${fmtSize(video.size)}`),

--- a/public/partials/navbar.html
+++ b/public/partials/navbar.html
@@ -1,0 +1,26 @@
+<nav class="navbar navbar-expand-lg">
+  <a class="navbar-brand" href="/">ARAGLAS</a>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span><i class="fa-solid fa-bars"></i></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarSupportedContent">
+    <ul class="navbar-nav mr-auto">
+      <li class="nav-item"><a class="nav-link" href="/channels/">Channels</a></li>
+      <li class="nav-item"><a class="nav-link" href="/favorites/">Favorites</a></li>
+      <li class="nav-item"><a class="nav-link" href="/playlists/">Playlists</a></li>
+      <li class="nav-item"><a class="nav-link" href="/moments/">Moments</a></li>
+      <li class="nav-item"><a class="nav-link" href="/stats/">Stats</a></li>
+    </ul>
+    <form class="form-inline my-2 my-lg-0" onsubmit="event.preventDefault(); var q = this.querySelector('input').value.trim(); if(q) { window.location = '/search/?q=' + encodeURIComponent(q); } else { alert('Please enter a search query.'); } return false;">
+      <div class="navbar-search-wrap" style="display:flex;align-items:center;gap:10px;">
+        <input id="navbar-search" class="form-control mr-sm-2" type="search" placeholder="Search videos..." aria-label="Search videos...">
+      </div>
+      <button type="button" class="btn btn-outline-danger my-2 my-sm-0" style="font-size:1.2em;display:inline-flex;align-items:center;justify-content:center;margin-left:10px;" title="Surprise Me" onclick="window.surpriseMe && window.surpriseMe();">
+        <i class="fa-solid fa-face-surprise"></i>
+      </button>
+      <button type="button" class="btn btn-outline-danger my-2 my-sm-0" style="font-size:1.2em;display:inline-flex;align-items:center;justify-content:center;margin-left:8px;" title="Toggle Theme" onclick="window.toggleTheme && window.toggleTheme();">
+        <i class="fa-solid fa-circle-half-stroke"></i>
+      </button>
+    </form>
+  </div>
+</nav>

--- a/public/partials/navbar.js
+++ b/public/partials/navbar.js
@@ -1,0 +1,7 @@
+export async function loadNavbar() {
+  const el = document.getElementById('navbar');
+  if (!el) return;
+  const res = await fetch('/partials/navbar.html');
+  const html = await res.text();
+  el.innerHTML = html;
+}

--- a/public/playlist/index.html
+++ b/public/playlist/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Araglas – Playlist</title>
+  <link rel="stylesheet" href="/app-main.css" id="theme-dark" />
+  <link rel="stylesheet" href="/app-main-light.css" id="theme-light" disabled />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+  <link rel="icon" type="image/png" href="/icons/araglas.ico" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <div id="app"></div>
+  <script type="module">
+    import { renderPlaylistDetail } from '/pages/playlists.js';
+    import { applyThemeFromSettings, attachGlobals } from '/pages/_shared.js';
+    import { loadNavbar } from '/partials/navbar.js';
+    applyThemeFromSettings();
+    attachGlobals();
+    loadNavbar();
+    renderPlaylistDetail();
+  </script>
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/public/playlists/index.html
+++ b/public/playlists/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Araglas – Playlists</title>
+  <link rel="stylesheet" href="/app-main.css" id="theme-dark" />
+  <link rel="stylesheet" href="/app-main-light.css" id="theme-light" disabled />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+  <link rel="icon" type="image/png" href="/icons/araglas.ico" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <div id="app"></div>
+  <script type="module">
+    import { renderPlaylists } from '/pages/playlists.js';
+    import { applyThemeFromSettings, attachGlobals } from '/pages/_shared.js';
+    import { loadNavbar } from '/partials/navbar.js';
+    applyThemeFromSettings();
+    attachGlobals();
+    loadNavbar();
+    renderPlaylists();
+  </script>
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/public/search/index.html
+++ b/public/search/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Araglas – Search</title>
+  <link rel="stylesheet" href="/app-main.css" id="theme-dark" />
+  <link rel="stylesheet" href="/app-main-light.css" id="theme-light" disabled />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+  <link rel="icon" type="image/png" href="/icons/araglas.ico" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <div id="app"></div>
+  <script type="module">
+    import { renderSearch } from '/pages/search.js';
+    import { applyThemeFromSettings, attachGlobals } from '/pages/_shared.js';
+    import { loadNavbar } from '/partials/navbar.js';
+    applyThemeFromSettings();
+    attachGlobals();
+    loadNavbar();
+    renderSearch();
+  </script>
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/public/stats/index.html
+++ b/public/stats/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Araglas – Stats</title>
+  <link rel="stylesheet" href="/app-main.css" id="theme-dark" />
+  <link rel="stylesheet" href="/app-main-light.css" id="theme-light" disabled />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+  <link rel="icon" type="image/png" href="/icons/araglas.ico" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <div id="app"></div>
+  <script type="module">
+    import { renderStats } from '/pages/stats.js';
+    import { applyThemeFromSettings, attachGlobals } from '/pages/_shared.js';
+    import { loadNavbar } from '/partials/navbar.js';
+    applyThemeFromSettings();
+    attachGlobals();
+    loadNavbar();
+    renderStats();
+  </script>
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/public/watch/index.html
+++ b/public/watch/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Araglas – Watch</title>
+  <link rel="stylesheet" href="/app-main.css" id="theme-dark" />
+  <link rel="stylesheet" href="/app-main-light.css" id="theme-light" disabled />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+  <link rel="icon" type="image/png" href="/icons/araglas.ico" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <div id="app"></div>
+  <script type="module">
+    import { renderWatch } from '/pages/watch.js';
+    import { applyThemeFromSettings, attachGlobals } from '/pages/_shared.js';
+    import { loadNavbar } from '/partials/navbar.js';
+    applyThemeFromSettings();
+    attachGlobals();
+    loadNavbar();
+    renderWatch();
+  </script>
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/server/index.js
+++ b/server/index.js
@@ -45,6 +45,39 @@ app.disable("x-powered-by");
 app.use(morgan("tiny"));
 app.use(express.static(path.join(__dirname, "..", "public"), { maxAge: "1h", etag: true }));
 
+// Path-based pages (no hash routing)
+app.get('/', (req, res) => res.redirect('/home/'));
+app.get(['/home', '/home/'], (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'public', 'home', 'index.html'));
+});
+app.get(['/channels', '/channels/'], (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'public', 'channels', 'index.html'));
+});
+app.get(['/channel', '/channel/'], (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'public', 'channel', 'index.html'));
+});
+app.get(['/search', '/search/'], (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'public', 'search', 'index.html'));
+});
+app.get(['/playlists', '/playlists/'], (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'public', 'playlists', 'index.html'));
+});
+app.get(['/playlist', '/playlist/'], (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'public', 'playlist', 'index.html'));
+});
+app.get(['/favorites', '/favorites/'], (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'public', 'favorites', 'index.html'));
+});
+app.get(['/moments', '/moments/'], (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'public', 'moments', 'index.html'));
+});
+app.get(['/stats', '/stats/'], (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'public', 'stats', 'index.html'));
+});
+app.get(['/watch', '/watch/'], (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'public', 'watch', 'index.html'));
+});
+
 // Serve actual videos directly with range support using express static under /video
 app.use("/video", express.static(LIBRARY_DIR, {
   acceptRanges: true,
@@ -430,10 +463,8 @@ app.delete("/api/moments", express.json(), async (req, res) => {
   res.json({ ok: true });
 });
 
-// Fallback to SPA
-app.get("*", (req, res) => {
-  res.sendFile(path.join(__dirname, "..", "public", "index.html"));
-});
+// Fallback to home for unknown paths under our domain (optional)
+app.get('*', (req, res) => res.redirect('/home/'));
 
 app.listen(PORT, () => {
   console.log(`Araglas running on http://localhost:${PORT}`);

--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,7 @@ import { scanLibrary } from "./scanner.js";
 import { ensureThumbsDir, makeThumb, thumbPathFor } from "./thumbs.js";
 import { matchesQuery, paginate, PAGE_SIZE_DEFAULT, hashPath } from "./utils.js";
 import mime from "mime";
+import nunjucks from "nunjucks";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -43,40 +44,28 @@ watcher.on("all", async () => {
 const app = express();
 app.disable("x-powered-by");
 app.use(morgan("tiny"));
-app.use(express.static(path.join(__dirname, "..", "public"), { maxAge: "1h", etag: true }));
+
+// Views (Nunjucks)
+const VIEWS_DIR = path.join(__dirname, "..", "views");
+nunjucks.configure(VIEWS_DIR, { autoescape: true, express: app });
+app.set("views", VIEWS_DIR);
+app.set("view engine", "njk");
 
 // Path-based pages (no hash routing)
 app.get('/', (req, res) => res.redirect('/home/'));
-app.get(['/home', '/home/'], (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'public', 'home', 'index.html'));
-});
-app.get(['/channels', '/channels/'], (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'public', 'channels', 'index.html'));
-});
-app.get(['/channel', '/channel/'], (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'public', 'channel', 'index.html'));
-});
-app.get(['/search', '/search/'], (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'public', 'search', 'index.html'));
-});
-app.get(['/playlists', '/playlists/'], (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'public', 'playlists', 'index.html'));
-});
-app.get(['/playlist', '/playlist/'], (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'public', 'playlist', 'index.html'));
-});
-app.get(['/favorites', '/favorites/'], (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'public', 'favorites', 'index.html'));
-});
-app.get(['/moments', '/moments/'], (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'public', 'moments', 'index.html'));
-});
-app.get(['/stats', '/stats/'], (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'public', 'stats', 'index.html'));
-});
-app.get(['/watch', '/watch/'], (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'public', 'watch', 'index.html'));
-});
+app.get(['/home', '/home/'], (req, res) => res.render('home.njk'));
+app.get(['/channels', '/channels/'], (req, res) => res.render('channels.njk'));
+app.get(['/channel', '/channel/'], (req, res) => res.render('channel.njk'));
+app.get(['/search', '/search/'], (req, res) => res.render('search.njk'));
+app.get(['/playlists', '/playlists/'], (req, res) => res.render('playlists.njk'));
+app.get(['/playlist', '/playlist/'], (req, res) => res.render('playlist.njk'));
+app.get(['/favorites', '/favorites/'], (req, res) => res.render('favorites.njk'));
+app.get(['/moments', '/moments/'], (req, res) => res.render('moments.njk'));
+app.get(['/stats', '/stats/'], (req, res) => res.render('stats.njk'));
+app.get(['/watch', '/watch/'], (req, res) => res.render('watch.njk'));
+
+// Static assets (served after view routes so SSR wins for page paths)
+app.use(express.static(path.join(__dirname, "..", "public"), { maxAge: "1h", etag: true }));
 
 // Serve actual videos directly with range support using express static under /video
 app.use("/video", express.static(LIBRARY_DIR, {

--- a/views/channel.njk
+++ b/views/channel.njk
@@ -1,0 +1,8 @@
+{% extends "layout.njk" %}
+{% block title %}Araglas — Channel{% endblock %}
+{% block page_script %}
+<script type="module">
+  import { renderChannel } from '/pages/channel.js';
+  renderChannel();
+</script>
+{% endblock %}

--- a/views/channels.njk
+++ b/views/channels.njk
@@ -1,0 +1,8 @@
+{% extends "layout.njk" %}
+{% block title %}Araglas — Channels{% endblock %}
+{% block page_script %}
+<script type="module">
+  import { renderChannels } from '/pages/channels.js';
+  renderChannels();
+</script>
+{% endblock %}

--- a/views/favorites.njk
+++ b/views/favorites.njk
@@ -1,0 +1,8 @@
+{% extends "layout.njk" %}
+{% block title %}Araglas — Favorites{% endblock %}
+{% block page_script %}
+<script type="module">
+  import { renderFavorites } from '/pages/favorites.js';
+  renderFavorites();
+</script>
+{% endblock %}

--- a/views/home.njk
+++ b/views/home.njk
@@ -1,0 +1,8 @@
+{% extends "layout.njk" %}
+{% block title %}Araglas — Home{% endblock %}
+{% block page_script %}
+<script type="module">
+  import { renderHome } from '/pages/home.js';
+  renderHome();
+</script>
+{% endblock %}

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+  <title>{% block title %}Araglas{% endblock %}</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <link rel="icon" type="image/png" href="/icons/araglas.ico" />
+  <link rel="stylesheet" href="/app-main.css" id="theme-dark" />
+  <link rel="stylesheet" href="/app-main-light.css" id="theme-light" disabled />
+</head>
+<body>
+  {% include "partials/navbar.njk" %}
+  <div id="app"></div>
+
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+
+  <script type="module">
+    import { applyThemeFromSettings, attachGlobals } from '/pages/_shared.js';
+    applyThemeFromSettings();
+    attachGlobals();
+  </script>
+
+  {% block page_script %}{% endblock %}
+</body>
+</html>

--- a/views/moments.njk
+++ b/views/moments.njk
@@ -1,0 +1,8 @@
+{% extends "layout.njk" %}
+{% block title %}Araglas — Moments{% endblock %}
+{% block page_script %}
+<script type="module">
+  import { renderMoments } from '/pages/moments.js';
+  renderMoments();
+</script>
+{% endblock %}

--- a/views/partials/navbar.njk
+++ b/views/partials/navbar.njk
@@ -1,0 +1,26 @@
+<nav class="navbar navbar-expand-lg">
+  <a class="navbar-brand" href="/">ARAGLAS</a>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span><i class="fa-solid fa-bars"></i></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarSupportedContent">
+    <ul class="navbar-nav mr-auto">
+      <li class="nav-item"><a class="nav-link" href="/channels/">Channels</a></li>
+      <li class="nav-item"><a class="nav-link" href="/favorites/">Favorites</a></li>
+      <li class="nav-item"><a class="nav-link" href="/playlists/">Playlists</a></li>
+      <li class="nav-item"><a class="nav-link" href="/moments/">Moments</a></li>
+      <li class="nav-item"><a class="nav-link" href="/stats/">Stats</a></li>
+    </ul>
+    <form class="form-inline my-2 my-lg-0" onsubmit="event.preventDefault(); var q = this.querySelector('input').value.trim(); if(q) { window.location = '/search/?q=' + encodeURIComponent(q); } else { alert('Please enter a search query.'); } return false;">
+      <div class="navbar-search-wrap" style="display:flex;align-items:center;gap:10px;">
+        <input id="navbar-search" class="form-control mr-sm-2" type="search" placeholder="Search videos..." aria-label="Search videos...">
+      </div>
+      <button type="button" class="btn btn-outline-danger my-2 my-sm-0" style="font-size:1.2em;display:inline-flex;align-items:center;justify-content:center;margin-left:10px;" title="Surprise Me" onclick="window.surpriseMe && window.surpriseMe();">
+        <i class="fa-solid fa-face-surprise"></i>
+      </button>
+      <button type="button" class="btn btn-outline-danger my-2 my-sm-0" style="font-size:1.2em;display:inline-flex;align-items:center;justify-content:center;margin-left:8px;" title="Toggle Theme" onclick="window.toggleTheme && window.toggleTheme();">
+        <i class="fa-solid fa-circle-half-stroke"></i>
+      </button>
+    </form>
+  </div>
+</nav>

--- a/views/playlist.njk
+++ b/views/playlist.njk
@@ -1,0 +1,8 @@
+{% extends "layout.njk" %}
+{% block title %}Araglas — Playlist{% endblock %}
+{% block page_script %}
+<script type="module">
+  import { renderPlaylistDetail } from '/pages/playlists.js';
+  renderPlaylistDetail();
+</script>
+{% endblock %}

--- a/views/playlists.njk
+++ b/views/playlists.njk
@@ -1,0 +1,8 @@
+{% extends "layout.njk" %}
+{% block title %}Araglas — Playlists{% endblock %}
+{% block page_script %}
+<script type="module">
+  import { renderPlaylists } from '/pages/playlists.js';
+  renderPlaylists();
+</script>
+{% endblock %}

--- a/views/search.njk
+++ b/views/search.njk
@@ -1,0 +1,8 @@
+{% extends "layout.njk" %}
+{% block title %}Araglas — Search{% endblock %}
+{% block page_script %}
+<script type="module">
+  import { renderSearch } from '/pages/search.js';
+  renderSearch();
+</script>
+{% endblock %}

--- a/views/stats.njk
+++ b/views/stats.njk
@@ -1,0 +1,8 @@
+{% extends "layout.njk" %}
+{% block title %}Araglas — Stats{% endblock %}
+{% block page_script %}
+<script type="module">
+  import { renderStats } from '/pages/stats.js';
+  renderStats();
+</script>
+{% endblock %}

--- a/views/watch.njk
+++ b/views/watch.njk
@@ -1,0 +1,8 @@
+{% extends "layout.njk" %}
+{% block title %}Araglas — Watch{% endblock %}
+{% block page_script %}
+<script type="module">
+  import { renderWatch } from '/pages/watch.js';
+  renderWatch();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary by Sourcery

Refactor routing to use path-based URLs instead of hash-based navigation throughout the application

New Features:
- Define explicit Express routes for each page path and redirect unknown paths to /home
- Add pages/_shared.js module with query parameter parsing, theme management, and global utilities (surpriseMe, toggleTheme, etc)
- Create standalone index.html entry points and navbar partial under public for each route

Enhancements:
- Replace parseHashParams and hashchange events with getQueryParams, location.href navigation, and location.reload across client pages
- Serve static HTML for each route on the server instead of falling back to a single SPA entry point